### PR TITLE
ci: yarn engine version use caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "bumbledos@gmail.com",
   "license": "MIT",
   "engines": {
-    "yarn": ">=1.21.1 <=1.22.18"
+    "yarn": "^1.21.1"
   },
   "dependencies": {
     "@babel/core": "^7.13.15",


### PR DESCRIPTION
Сборки будут ломаться, т.к. раннеры переходят на [Yarn 1.22.19](https://github.com/actions/virtual-environments/blob/ubuntu20/20220614.0/images/linux/Ubuntu2004-Readme.md#:~:text=Yarn%201.22.19)